### PR TITLE
Make default DB localhost

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -12,11 +12,12 @@ DB_DUMP_BEGIN=${DB_DUMP_BEGIN:-+0}
 # DB_DUMP_TARGET = where to place the backup file. Can be URL (e.g. smb://server/share/path) or just file path /foo
 DB_DUMP_TARGET=${DB_DUMP_TARGET:-/backup}
 # login credentials
+DBSERVER=${DB_HOST:-localhost}
 DBUSER=${DB_USER:-cattle}
 DBPASS=${DB_PASS:-cattle}
 
 # database server
-DBSERVER=db
+#DBSERVER=db
 
 # temporary dump dir
 TMPDIR=/tmp/backups

--- a/entrypoint
+++ b/entrypoint
@@ -26,7 +26,10 @@ TMPRESTORE=/tmp/restorefile
 # this is global, so has to be set outside
 declare -A uri
 
-
+# check /var/run/mysqld/mysqld.sock
+# if we have it link to /run
+test -e /var/run/mysqld/mysqld.sock \
+  && ln -s /var/run/mysqld /run/mysqld
 
 #
 # URI parsing function


### PR DESCRIPTION
with default db localhost user can use typically created mysql login values, with the DBSERVER set to "db" there need be a login for each potential host providing backups  'cattle'@'{HOST}' IDENTIFIED BY 'password'
